### PR TITLE
feat: Add array support for status filter parameter in list endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "me.farshad"
-version = "1.0.9-SNAPSHOT"
+version = "1.0.11-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/me/farshad/dsl/builder/paths/OperationBuilder.kt
+++ b/src/main/kotlin/me/farshad/dsl/builder/paths/OperationBuilder.kt
@@ -34,7 +34,8 @@ class OperationBuilder {
         required: Boolean = false,
         description: String? = null,
         format: SchemaFormat? = null,
-        examples: Map<String,Example>? = null,
+        examples: Map<String, Example>? = null,
+        items: Schema? = null,
     ) {
         parameters.add(
             Parameter(
@@ -55,6 +56,7 @@ class OperationBuilder {
                                 PropertyType.NULL -> SchemaType.NULL
                             },
                         format = format,
+                        items = items,
                     ),
                 examples = examples,
             ),

--- a/src/main/kotlin/me/farshad/dsl/builder/utils/JsonUtils.kt
+++ b/src/main/kotlin/me/farshad/dsl/builder/utils/JsonUtils.kt
@@ -15,6 +15,7 @@ private val logger = KotlinLogging.logger {}
 // Helper function to create JsonElement from any value
 fun Any.toJsonElement(): JsonElement =
     when (this) {
+        is JsonElement -> this
         is String -> JsonPrimitive(this)
         is Number -> JsonPrimitive(this)
         is Boolean -> JsonPrimitive(this)

--- a/src/test/kotlin/me/farshad/dsl/builder/utils/HelperFunctionsTest.kt
+++ b/src/test/kotlin/me/farshad/dsl/builder/utils/HelperFunctionsTest.kt
@@ -150,9 +150,9 @@ class HelperFunctionsTest {
         val obj = NonSerializableObject("test")
         val result = obj.toJsonElement()
 
-        // Should fall back to toString()
-        assertTrue(result is JsonPrimitive)
-        assertEquals("NonSerializableObject: test", result.content)
+        assertTrue(result is JsonObject)
+        // The result is an empty JsonObject since the property is private
+        assertEquals(0, (result as JsonObject).size)
     }
 
     // toSerializableJsonElement tests

--- a/src/test/kotlin/me/farshad/dsl/spec/JsonContentExamplesTest.kt
+++ b/src/test/kotlin/me/farshad/dsl/spec/JsonContentExamplesTest.kt
@@ -284,26 +284,26 @@ class JsonContentExamplesTest {
         val nameUpdate = examples["name_update"]?.jsonObject
         assertNotNull(nameUpdate)
         assertEquals("Update name only", nameUpdate["summary"]?.jsonPrimitive?.content)
-        // The value gets double-encoded as a string: "\"New Name\""
+        // Value is properly serialized as a JsonObject
         val nameValue =
             nameUpdate["value"]
                 ?.jsonObject
                 ?.get("name")
                 ?.jsonPrimitive
                 ?.content
-        assertEquals("\"New Name\"", nameValue)
+        assertEquals("New Name", nameValue)
 
         val emailUpdate = examples["email_update"]?.jsonObject
         assertNotNull(emailUpdate)
         assertEquals("Update email only", emailUpdate["summary"]?.jsonPrimitive?.content)
-        // The value gets double-encoded as a string: "\"newemail@example.com\""
+        // Value is properly serialized as a JsonObject
         val emailValue =
             emailUpdate["value"]
                 ?.jsonObject
                 ?.get("email")
                 ?.jsonPrimitive
                 ?.content
-        assertEquals("\"newemail@example.com\"", emailValue)
+        assertEquals("newemail@example.com", emailValue)
     }
 
     @Test


### PR DESCRIPTION
  - Update status examples to use JSON arrays across all list endpoints: list customers, accounts, contracts, managers, drivers, tenants
  - Add multiple status filter examples